### PR TITLE
ToEquals for maybe and either monads

### DIFF
--- a/MonadicBits/Enumerable.cs
+++ b/MonadicBits/Enumerable.cs
@@ -1,8 +1,18 @@
+using System;
 using System.Collections.Generic;
 
 namespace MonadicBits
 {
+    [Obsolete("use MonadicEnumerable instead")]
     public static class Enumerable
+    {
+        public static IEnumerable<T> Return<T>(T value)
+        {
+            yield return value;
+        }
+    }
+    
+    public static class MonadicEnumerable
     {
         public static IEnumerable<T> Return<T>(T value)
         {

--- a/MonadicBits/Maybe.cs
+++ b/MonadicBits/Maybe.cs
@@ -58,12 +58,32 @@ namespace MonadicBits
 
         public static implicit operator Maybe<T>(T value) =>
             value == null ? Nothing : new Maybe<T>(value);
+
+        public override string ToString() => IsJust ? $"Just: {{{Instance}}}" : nameof(Nothing);
+
+        public override int GetHashCode() => IsJust ? Instance.GetHashCode() : 0;
+
+        public override bool Equals(object obj) =>
+            obj switch
+            {
+                Nothing _ => !IsJust,
+                Maybe<T> other => Equals(other),
+                T otherValue when IsJust => Equals(Instance, otherValue),
+                _ => false
+            };
+
+        public bool Equals(Maybe<T> other) =>
+            other.IsJust == IsJust && Equals(other.Instance, Instance);
     }
 
     namespace Maybe
     {
         public readonly struct Nothing
         {
+            public override int GetHashCode() => 0;
+
+            public override bool Equals(object obj) =>
+                obj is Nothing || obj != null && obj.Equals(this);
         }
     }
 }

--- a/MonadicBitsTests/EitherTests.cs
+++ b/MonadicBitsTests/EitherTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using FluentAssertions;
 using MonadicBits;
 using NUnit.Framework;
 
 namespace MonadicBitsTests
 {
+    using static Functional;
+
     public static class EitherTests
     {
         [Test]
@@ -60,8 +63,9 @@ namespace MonadicBitsTests
         public static void Map_right_either_returns_either_with_new_type_and_value()
         {
             const int mappedValue = 42;
-            TestMonads.Right("Test").Map(_ => mappedValue)
-                .Match(Assert.Fail, i => Assert.AreEqual(mappedValue, i));
+            TestMonads.Right("Test")
+                .Map(_ => mappedValue)
+                .Should().Be(mappedValue.Right());
         }
 
         [Test]
@@ -80,15 +84,20 @@ namespace MonadicBitsTests
         public static void MapLeft_left_either_returns_either_with_new_type_and_value()
         {
             const int mappedValue = 42;
-            TestMonads.Left("Test").MapLeft(_ => mappedValue)
-                .Match(i => Assert.AreEqual(mappedValue, i), Assert.Fail);
+            TestMonads.Left("Test")
+                .MapLeft(_ => mappedValue)
+                .Should()
+                .Be(mappedValue.Left());
         }
 
         [Test]
         public static void MapLeft_right_either_returns_same_right_either()
         {
             const string value = "Test";
-            TestMonads.Right(value).MapLeft(_ => 42).Match(_ => Assert.Fail(), s => Assert.AreEqual(value, s));
+            TestMonads.Right(value)
+                .MapLeft(_ => 42)
+                .Should()
+                .Be(value.Right());
         }
 
         [Test]
@@ -100,16 +109,18 @@ namespace MonadicBitsTests
         public static void Bind_right_either_to_method_returns_either_with_new_type_and_value()
         {
             const int bindValue = 42;
-            TestMonads.Right("Test").Bind(_ => bindValue.Right<string, int>())
-                .Match(Assert.Fail, i => Assert.AreEqual(bindValue, i));
+            TestMonads.Right("Test")
+                .Bind(_ => bindValue.Right<string, int>())
+                .Should().Be(bindValue.Right());
         }
 
         [Test]
-        public static void Bind_left_either_to_method_returns_same_left_either()
+        public static void Bind_on_left_changes_right_type_only()
         {
             const string value = "Test";
-            TestMonads.Left(value).Bind(_ => 42.Right<string, int>())
-                .Match(s => Assert.AreEqual(value, s), _ => Assert.Fail());
+            TestMonads.Left(value)
+                .Bind(_ => 42.Right<string, int>())
+                .Should().Be(value.Left<string, int>());
         }
 
         [Test]
@@ -118,30 +129,85 @@ namespace MonadicBitsTests
                 TestMonads.Left("Test").BindLeft((Func<string, Either<string, string>>)null));
 
         [Test]
-        public static void BindLeft_left_either_to_method_returns_either_with_new_type_and_value()
+        public static void BindLeft_on_left_changes_left_type_and_value()
         {
             const int bindValue = 42;
-            TestMonads.Left("Test").BindLeft(_ => bindValue.Left<int, string>())
-                .Match(i => Assert.AreEqual(bindValue, i), Assert.Fail);
+            TestMonads.Left("Test")
+                .BindLeft(_ => bindValue.Left<int, string>())
+                .Should().Be(bindValue.Left());
         }
 
         [Test]
-        public static void BindLeft_right_either_to_method_returns_same_right_either()
+        public static void BindLeft_on_right_changes_left_type_only()
         {
             const string value = "Test";
-            TestMonads.Right(value).BindLeft(_ => 42.Left<int, string>())
-                .Match(_ => Assert.Fail(), s => Assert.AreEqual(value, s));
+            TestMonads.Right(value)
+                .BindLeft(_ => 42.Left<int, string>())
+                .Should().Be(value.Right<int, string>());
         }
 
         [Test]
-        public static void Left_to_maybe_returns_empty_maybe() =>
-            TestMonads.Left("Test").ToMaybe().Match(Assert.Fail, Assert.Pass);
+        public static void Left_to_maybe_returns_nothing() =>
+            TestMonads.Left("Test").ToMaybe()
+                .Should().Be(Nothing);
 
         [Test]
-        public static void Right_to_maybe_returns_maybe_with_value()
+        public static void Right_to_maybe_returns_just()
         {
             const string value = "Test";
-            TestMonads.Right(value).ToMaybe().Match(s => Assert.AreEqual(value, s), Assert.Fail);
+            TestMonads.Right(value)
+                .ToMaybe().Should().Be(value.Just());
         }
+
+        [Test]
+        public static void BindLeft_on_explicit_left_changes_left_value_and_type() =>
+            42.Left().BindLeft(v => v.ToString().Left<string, string>())
+                .Should().Be(42.ToString().Left());
+
+        [Test]
+        public static void Bind_on_explicit_right_changes_value_and_type() =>
+            42.Right().Bind(v => v.ToString().Right<int, string>())
+                .Should().Be(42.ToString().Right());
+
+        [Test]
+        public static void Left_does_not_equal_arbitrary_right_of_same_type() =>
+            42.Left<int, string>().Should().NotBe("right".Right<int, string>());
+
+        [Test]
+        public static void Left_does_not_equal_arbitrary_value_of_correct_right_type() =>
+            42.Left<int, string>().Should().NotBe("right");
+
+        [Test]
+        public static void Right_does_not_equal_arbitrary_left_of_same_type() =>
+            42.Right<string, int>().Should().NotBe("right".Left<string, int>());
+
+        [Test]
+        public static void Right_does_not_equal_arbitrary_value_of_correct_left_type() =>
+            42.Right<string, int>().Should().NotBe("right");
+
+        [Test]
+        public static void Hash_codes_of_same_value_right_are_equal() =>
+            42.Right<int, int>().GetHashCode().Should().Be(42.Right<int, int>().GetHashCode());
+
+        [Test]
+        public static void Hash_codes_of_same_value_left_are_equal() =>
+            42.Left<int, int>().GetHashCode().Should().Be(42.Left<int, int>().GetHashCode());
+
+        [Test]
+        public static void Hash_codes_of_same_value_left_and_right_are_not_equal() =>
+            42.Left<int, int>().GetHashCode().Should().NotBe(42.Right<int, int>().GetHashCode());
+
+        [Test]
+        public static void String_representation_of_left_contains_value_representation() =>
+            42.Left<int, int>().ToString().Should().Contain(42.ToString());
+
+        [Test]
+        public static void String_representation_of_right_contains_value_representation() =>
+            42.Right<int, int>().ToString().Should().Contain(42.ToString());
+
+        [Test]
+        public static void String_representation_of_right_and_left_with_same_value_and_type_are_not_equal() =>
+            42.Right<int, int>().ToString()
+                .Should().NotBe(42.Left<int, int>().ToString());
     }
 }

--- a/MonadicBitsTests/EnumerableTests.cs
+++ b/MonadicBitsTests/EnumerableTests.cs
@@ -7,6 +7,6 @@ namespace MonadicBitsTests
     {
         [Test]
         public static void Elevation_creates_single_item_enumeration() =>
-            MonadicBits.Enumerable.Return(42).Should().BeEquivalentTo(new[] { 42 });
+            MonadicBits.MonadicEnumerable.Return(42).Should().BeEquivalentTo(new[] { 42 });
     }
 }

--- a/MonadicBitsTests/MaybeAsyncExtensionsTests.cs
+++ b/MonadicBitsTests/MaybeAsyncExtensionsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using MonadicBits;
 using NUnit.Framework;
 using static MonadicBitsTests.TestMonads;
@@ -13,20 +14,20 @@ namespace MonadicBitsTests
         {
             const int input = 42;
             (await "Test".Just().MapAsync(_ => Task.FromResult(input)))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
         public static async Task MapAsync_empty_maybe_to_async_mapping_returns_empty_maybe_task() =>
             (await Nothing<string>().MapAsync(_ => Task.FromResult(42)))
-            .Match(_ => Assert.Fail(), Assert.Pass);
+            .Should().Be(Functional.Nothing);
 
         [Test]
         public static async Task MapAsync_maybe_task_with_value_to_mapping_returns_maybe_task_with_new_value()
         {
             const int input = 42;
             (await Task.FromResult("Test".Just()).MapAsync(_ => input))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
@@ -34,33 +35,33 @@ namespace MonadicBitsTests
         {
             const int input = 42;
             (await Task.FromResult("Test".Just()).MapAsync(_ => Task.FromResult(input)))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
         public static void BindAsync_with_null_mapping_throws_exception() =>
             Assert.ThrowsAsync<ArgumentNullException>(() =>
-                "Test".Just().BindAsync((Func<string, Task<Maybe<string>>>) null));
+                "Test".Just().BindAsync((Func<string, Task<Maybe<string>>>)null));
 
         [Test]
         public static async Task BindAsync_maybe_with_value_to_async_mapping_returns_maybe_task_with_new_value()
         {
             const int input = 42;
             (await "Test".Just().BindAsync(_ => Task.FromResult(input.Just())))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
         public static async Task BindAsync_empty_maybe_to_async_mapping_empty_maybe_task() =>
             (await Nothing<string>().BindAsync(_ => Task.FromResult(42.Just())))
-            .Match(_ => Assert.Fail(), Assert.Pass);
+            .Should().Be(Functional.Nothing);
 
         [Test]
         public static async Task BindAsync_maybe_task_with_value_to_mapping_returns_maybe_task_with_new_value()
         {
             const int input = 42;
             (await Task.FromResult("Test".Just()).BindAsync(_ => input.Just()))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
@@ -68,7 +69,7 @@ namespace MonadicBitsTests
         {
             const int input = 42;
             (await Task.FromResult("Test".Just()).BindAsync(_ => Task.FromResult(input.Just())))
-                .Match(i => Assert.AreEqual(input, i), Assert.Fail);
+                .Should().Be(input.Just());
         }
     }
 }

--- a/MonadicBitsTests/MaybeExtensionsTests.cs
+++ b/MonadicBitsTests/MaybeExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.Intrinsics.Arm;
 using FluentAssertions;
+using Microsoft.VisualBasic.CompilerServices;
 using MonadicBits;
 using NUnit.Framework;
 
@@ -14,27 +16,29 @@ namespace MonadicBitsTests
         public static void Just_creates_maybe_with_value()
         {
             const string input = "Test";
-            input.Just().Match(s => Assert.AreEqual(input, s), Assert.Fail);
+            input.Just().Match(
+                j => Assert.That(j, Is.EqualTo(input)),
+                Assert.Fail);
         }
 
         [Test]
         public static void JustNotNull_creates_empty_maybe_from_null() =>
-            ((string)null).JustNotNull().Match(Assert.Fail, Assert.Pass);
+            ((string)null).JustNotNull().Should().Be(Nothing);
 
         [Test]
         public static void JustNotNull_creates_maybe_with_value_from_not_null()
         {
             const string value = "Test";
-            value.JustNotNull().Match(s => Assert.AreEqual(value, s), Assert.Fail);
+            value.JustNotNull().Should().Be(value.Just());
         }
 
         [Test]
         public static void ToMaybe_creates_nothing_from_empty_nullable() =>
-            ((int?)null).ToMaybe().Match(_ => Assert.Fail(), Assert.Pass);
+            ((int?)null).ToMaybe().Should().Be(Nothing);
 
         [Test]
         public static void ToMaybe_creates_just_from_nullable_value() =>
-            ((int?)1).ToMaybe().Match(_ => Assert.Pass(), Assert.Fail);
+            ((int?)1).ToMaybe().Should().Be(1.Just());
 
         [Test]
         public static void Just_to_nullable_returns_value() =>
@@ -49,21 +53,21 @@ namespace MonadicBitsTests
         {
             const string initialValue = "value";
             initialValue.Just().Or(() => "alternative".Just())
-                .Match(j => j.Should().Be(initialValue), Assert.Fail);
+                .Should().Be(initialValue.Just());
         }
 
         [Test]
-        public static void Or_on_nothing_returns_initial_value()
+        public static void Or_on_nothing_returns_alternative_value()
         {
             const string alternativeValue = "alternative";
             TestMonads.Nothing<string>().Or(() => alternativeValue.Just())
-                .Match(j => j.Should().Be(alternativeValue), Assert.Fail);
+                .Should().Be(alternativeValue.Just());
         }
 
         [Test]
         public static void Or_on_nothing_and_nothing_alternative_returns_nothing() =>
             TestMonads.Nothing<string>().Or(() => Nothing)
-                .Match(Assert.Fail, Assert.Pass);
+                .Should().Be(Nothing);
 
         [Test]
         public static void Enumerable_created_from_just_contains_value()
@@ -80,7 +84,7 @@ namespace MonadicBitsTests
         public static void FirstOrNothing_with_list_of_values_returns_maybe_of_first_value()
         {
             List<int> values = new() { 23, 42, 15 };
-            values.FirstOrNothing().Match(i => Assert.AreEqual(values[0], i), Assert.Fail);
+            values.FirstOrNothing().Should().Be(values[0].Just());
         }
 
         [Test]
@@ -89,17 +93,17 @@ namespace MonadicBitsTests
             const int matchingValue = 25;
             var allValues = new[] { 1, 2, matchingValue, 34 };
             allValues.FirstOrNothing(v => v == matchingValue)
-                .Match(i => i.Should().Be(matchingValue), Assert.Fail);
+                .Should().Be(matchingValue.Just());
         }
 
         [Test]
         public static void FirstOrNothing_with_predicate_returns_nothing_when_no_item_matches() =>
             new[] { 1, 2, 34 }.FirstOrNothing(v => v == 25)
-                .Match(_ => Assert.Fail(), Assert.Pass);
+                .Should().Be(Nothing);
 
         [Test]
         public static void FirstOrNothing_with_empty_list_returns_nothing() =>
-            new List<int>().FirstOrNothing().Match(_ => Assert.Fail(), Assert.Pass);
+            new List<int>().FirstOrNothing().Should().Be(Nothing);
 
         [Test]
         public static void Just_throws_on_null() =>
@@ -113,14 +117,16 @@ namespace MonadicBitsTests
         public static void JustWhen_with_false_predicate_returns_nothing()
         {
             const string input = "Test";
-            input.JustWhen(s => s.Length == input.Length + 1).Match(_ => Assert.Fail(), Assert.Pass);
+            input.JustWhen(s => s.Length == input.Length + 1)
+                .Should().Be(Nothing);
         }
 
         [Test]
         public static void JustWhen_with_true_predicate_returns_just()
         {
             const string input = "Test";
-            input.JustWhen(s => s.Length == input.Length).Match(_ => Assert.Pass(), Assert.Fail);
+            input.JustWhen(s => s.Length == input.Length)
+                .Should().Be(input.Just());
         }
     }
 }

--- a/MonadicBitsTests/MaybeLinqAsyncExtensionsTest.cs
+++ b/MonadicBitsTests/MaybeLinqAsyncExtensionsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using MonadicBits;
 using NUnit.Framework;
 
@@ -12,7 +13,7 @@ namespace MonadicBitsTests
         {
             const string input = "Test";
             (await (from s in Task.FromResult(input.Just()) select s))
-                .Match(s => Assert.AreEqual(input, s), Assert.Fail);
+                .Should().Be(input.Just());
         }
 
         [Test]
@@ -35,7 +36,7 @@ namespace MonadicBitsTests
                 from s in Task.FromResult("Test".Just())
                 from i in Task.FromResult(input.Just())
                 select i
-            )).Match(i => Assert.AreEqual(input, i), Assert.Fail);
+            )).Should().Be(input.Just());
         }
     }
 }

--- a/MonadicBitsTests/MaybeLinqExtensionsTests.cs
+++ b/MonadicBitsTests/MaybeLinqExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using FluentAssertions;
 using MonadicBits;
 using NUnit.Framework;
 
@@ -10,7 +11,7 @@ namespace MonadicBitsTests
         public static void Select_from_maybe_with_value_returns_maybe_with_value()
         {
             const string input = "Test";
-            (from s in input.Just() select s).Match(s => Assert.AreEqual(input, s), Assert.Fail);
+            (from s in input.Just() select s).Should().Be(input.Just());
         }
 
         [Test]
@@ -31,7 +32,7 @@ namespace MonadicBitsTests
                 from s in "Test".Just()
                 from i in input.Just()
                 select i
-            ).Match(i => Assert.AreEqual(input, i), Assert.Fail);
+            ).Should().Be(input.Just());
         }
     }
 }

--- a/MonadicBitsTests/MaybeTests.cs
+++ b/MonadicBitsTests/MaybeTests.cs
@@ -1,5 +1,7 @@
 using System;
+using FluentAssertions;
 using MonadicBits;
+using MonadicBits.Maybe;
 using NUnit.Framework;
 using static MonadicBitsTests.TestMonads;
 
@@ -11,12 +13,12 @@ namespace MonadicBitsTests
         public static void Just_creates_maybe_with_value()
         {
             const string input = "Test";
-            input.Just().Match(s => Assert.AreEqual(input, s), Assert.Fail);
+            input.Just().Should().Be(input);
         }
 
         [Test]
         public static void Nothing_creates_empty_maybe() =>
-            Nothing<string>().Match(Assert.Fail, Assert.Pass);
+            Nothing<string>().Should().Be(Functional.Nothing);
 
         [Test]
         public static void Match_with_null_just_action_throws_exception() =>
@@ -58,33 +60,35 @@ namespace MonadicBitsTests
 
         [Test]
         public static void Map_with_null_mapping_throws_exception() =>
-            Assert.Throws<ArgumentNullException>(() => "Test".Just().Map((Func<string, string>) null));
+            Assert.Throws<ArgumentNullException>(() => "Test".Just().Map((Func<string, string>)null));
 
         [Test]
         public static void Map_maybe_with_value_returns_maybe_with_new_type_and_value()
         {
             const int mappedValue = 42;
-            "Test".Just().Map(_ => mappedValue).Match(i => Assert.AreEqual(mappedValue, i), Assert.Fail);
+            "Test".Just().Map(_ => mappedValue)
+                .Should().Be(mappedValue.Just());
         }
 
         [Test]
         public static void Map_empty_maybe_returns_empty_maybe() =>
-            Nothing<string>().Map(_ => 42).Match(_ => Assert.Fail(), Assert.Pass);
+            Nothing<string>().Map(_ => 42).Should().Be(Functional.Nothing);
 
         [Test]
         public static void Bind_to_null_method_throws_exception() =>
-            Assert.Throws<ArgumentNullException>(() => "Test".Just().Bind((Func<string, Maybe<string>>) null));
+            Assert.Throws<ArgumentNullException>(() => "Test".Just().Bind((Func<string, Maybe<string>>)null));
 
         [Test]
         public static void Bind_maybe_with_value_to_method_returns_maybe()
         {
             const int bindValue = 42;
-            "Test".Just().Bind(_ => bindValue.Just()).Match(i => Assert.AreEqual(bindValue, i), Assert.Fail);
+            "Test".Just().Bind(_ => bindValue.Just())
+                .Should().Be(bindValue.Just());
         }
 
         [Test]
         public static void Bind_empty_maybe_to_method_returns_empty_maybe() =>
-            Nothing<string>().Bind(_ => 42.Just()).Match(_ => Assert.Fail(), Assert.Pass);
+            Nothing<string>().Bind(_ => 42.Just()).Should().Be(Functional.Nothing);
 
         [Test]
         public static void Just_to_either_makes_right()
@@ -101,5 +105,57 @@ namespace MonadicBitsTests
             var result = Nothing<string>().ToEither(leftInput);
             result.Match(left => Assert.AreEqual(leftInput, left), Assert.Fail);
         }
+
+        [Test]
+        public static void String_representation_of_just_contains_value() =>
+            42.Just().ToString().Should().Contain(42.ToString());
+
+        [Test]
+        public static void String_representation_of_nothing_is_constant() =>
+            Nothing<int>().ToString().Should().Be(Nothing<string>().ToString());
+
+        [Test]
+        public static void Hash_code_of_just_is_hash_code_of_value() =>
+            "test".Just().GetHashCode().Should().Be("test".GetHashCode());
+
+        [Test]
+        public static void Hash_code_of_nothing_is_hash_code_of_explicit_nothing() =>
+            Nothing<int>().GetHashCode().Should().Be(new Nothing().GetHashCode());
+
+        [Test]
+        public static void Nothing_maybe_equals_explicit_nothing() =>
+            Nothing<int>().Should().Be(Functional.Nothing);
+
+        [Test]
+        public static void Explicit_nothing_equals_nothing_maybe_of_arbitrary_type() =>
+            Functional.Nothing.Should().Be(Nothing<int>());
+
+        [Test]
+        public static void Explicit_nothing_does_not_equal_null() =>
+            Functional.Nothing.Should().NotBe(null);
+
+        [Test]
+        public static void Nothing_does_not_equal_null() =>
+            Nothing<int>().Should().NotBe(null);
+
+        [Test]
+        public static void Just_equals_other_just_of_same_value() =>
+            42.Just().Should().Be(42.Just());
+
+        [Test]
+        public static void Just_does_not_equal_other_just_of_same_type() =>
+            42.Just().Should().NotBe(1.Just());
+
+        [Test]
+        public static void Just_does_not_equal_other_value_of_arbitrary_type() =>
+            42.Just().Should().NotBe(new object());
+
+        [Test]
+        public static void Just_does_not_equal_nothing() =>
+            42.Just().Should().NotBe(Nothing<int>());
+
+        [Test]
+        public static void Just_does_not_equal_explicit_nothing() =>
+            42.Just().Should().NotBe(Functional.Nothing);
     }
 }

--- a/MonadicBitsTests/TestMonads.cs
+++ b/MonadicBitsTests/TestMonads.cs
@@ -4,7 +4,7 @@ namespace MonadicBitsTests
 {
     public static class TestMonads
     {
-        public static Maybe<T> Nothing<T>() => Functional.Nothing;
+        public static Maybe<T> Nothing<T>() => default;
 
         public static Maybe<int> JustAnInt() => 42;
 


### PR DESCRIPTION
- enable comparison of maybe monads with Nothing and raw values
- override ToString for maybe and either monads for meaningful assertion messages and diagnostics
- enable comparison of either values