### PR TITLE
Added async functions for converting monad types

### DIFF
--- a/MonadicBits/EitherAsyncExtensions.cs
+++ b/MonadicBits/EitherAsyncExtensions.cs
@@ -9,7 +9,7 @@ namespace MonadicBits
             this Either<TLeft, TRight> either, Func<TRight, Task<TResult>> mapping,
             bool continueOnCapturedContext = false) =>
             either.Map(mapping).Match(
-                left => Task.FromResult<Either<TLeft,TResult>>(left.Left()),
+                left => Task.FromResult<Either<TLeft, TResult>>(left.Left()),
                 async task => (await task.ConfigureAwait(continueOnCapturedContext)).Right<TLeft, TResult>());
 
         public static Task<Either<TResult, TRight>> MapLeftAsync<TLeft, TRight, TResult>(
@@ -84,5 +84,12 @@ namespace MonadicBits
             bool continueOnCapturedContext = false) =>
             await (await eitherTask.ConfigureAwait(continueOnCapturedContext)).BindLeftAsync(mapping,
                 continueOnCapturedContext);
+
+        public static Task<Maybe<TRight>> ToMaybeAsync<TLeft, TRight>(this Either<TLeft, TRight> either) =>
+            Task.FromResult(either.ToMaybe());
+
+        public static async Task<Maybe<TRight>>
+            ToMaybeAsync<TLeft, TRight>(this Task<Either<TLeft, TRight>> eitherTask) =>
+            (await eitherTask).ToMaybe();
     }
 }

--- a/MonadicBits/MaybeAsyncExtensions.cs
+++ b/MonadicBits/MaybeAsyncExtensions.cs
@@ -39,5 +39,11 @@ namespace MonadicBits
             Func<T, Task<Maybe<TResult>>> mapping, bool continueOnCapturedContext = false) =>
             await (await maybeTask.ConfigureAwait(continueOnCapturedContext)).BindAsync(mapping,
                 continueOnCapturedContext);
+
+        public static Task<Either<TLeft, T>> ToEitherAsync<T, TLeft>(this Maybe<T> maybe, TLeft left) =>
+            Task.FromResult(maybe.ToEither(left));
+
+        public static async Task<Either<TLeft, T>> ToEitherAsync<T, TLeft>(this Task<Maybe<T>> maybeTask, TLeft left) =>
+            (await maybeTask).ToEither(left);
     }
 }

--- a/MonadicBitsTests/EitherAsyncExtensionsTests.cs
+++ b/MonadicBitsTests/EitherAsyncExtensionsTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Threading.Tasks;
+using FluentAssertions;
 using MonadicBits;
 using NUnit.Framework;
 
 namespace MonadicBitsTests
 {
+    using static Functional;
+
     public static class EitherAsyncExtensionsTests
     {
         [Test]
@@ -76,12 +79,12 @@ namespace MonadicBitsTests
         [Test]
         public static void BindAsync_with_null_mapping_throws_exception() =>
             Assert.ThrowsAsync<ArgumentNullException>(() =>
-                "Test".Right<string, string>().BindAsync((Func<string, Task<Either<string, string>>>) null));
+                "Test".Right<string, string>().BindAsync((Func<string, Task<Either<string, string>>>)null));
 
         [Test]
         public static void BindLeftAsync_with_null_mapping_throws_exception() =>
             Assert.ThrowsAsync<ArgumentNullException>(() =>
-                "Test".Left<string, string>().BindLeftAsync((Func<string, Task<Either<string, string>>>) null));
+                "Test".Left<string, string>().BindLeftAsync((Func<string, Task<Either<string, string>>>)null));
 
         [Test]
         public static async Task
@@ -153,6 +156,28 @@ namespace MonadicBitsTests
             (await Task.FromResult("Test".Left<string, string>())
                     .BindLeftAsync(_ => Task.FromResult(input.Left<int, string>())))
                 .Match(i => Assert.AreEqual(input, i), _ => Assert.Fail());
+        }
+
+        [Test]
+        public static async Task Left_to_async_maybe_returns_nothing_task() =>
+            (await TestMonads.Left("Test").ToMaybeAsync()).Should().Be(Nothing);
+
+        [Test]
+        public static async Task Right_to_async_maybe_returns_just_task()
+        {
+            const string value = "Test";
+            (await TestMonads.Right(value).ToMaybeAsync()).Should().Be(value.Just());
+        }
+
+        [Test]
+        public static async Task Left_task_to_async_maybe_returns_nothing_task() =>
+            (await Task.FromResult(TestMonads.Left("Test")).ToMaybeAsync()).Should().Be(Nothing);
+
+        [Test]
+        public static async Task Right_task_to_async_maybe_returns_just_task()
+        {
+            const string value = "Test";
+            (await Task.FromResult(TestMonads.Right(value)).ToMaybeAsync()).Should().Be(value.Just());
         }
     }
 }

--- a/MonadicBitsTests/MaybeAsyncExtensionsTests.cs
+++ b/MonadicBitsTests/MaybeAsyncExtensionsTests.cs
@@ -71,5 +71,37 @@ namespace MonadicBitsTests
             (await Task.FromResult("Test".Just()).BindAsync(_ => Task.FromResult(input.Just())))
                 .Should().Be(input.Just());
         }
+
+        [Test]
+        public static async Task Just_to_async_either_makes_right_task()
+        {
+            const string input = "Test";
+            var result = input.Just().ToEitherAsync("Left");
+            (await result).Match(Assert.Fail, right => Assert.AreEqual(input, right));
+        }
+
+        [Test]
+        public static async Task Nothing_to_async_either_makes_left_task()
+        {
+            const string leftInput = "Left";
+            var result = Nothing<string>().ToEitherAsync(leftInput);
+            (await result).Match(left => Assert.AreEqual(leftInput, left), Assert.Fail);
+        }
+
+        [Test]
+        public static async Task Just_task_to_async_either_makes_right_task()
+        {
+            const string input = "Test";
+            var result = Task.FromResult(input.Just()).ToEitherAsync("Left");
+            (await result).Match(Assert.Fail, right => Assert.AreEqual(input, right));
+        }
+
+        [Test]
+        public static async Task Nothing_task_to_async_either_makes_left_task()
+        {
+            const string leftInput = "Left";
+            var result = Task.FromResult(Nothing<string>()).ToEitherAsync(leftInput);
+            (await result).Match(left => Assert.AreEqual(leftInput, left), Assert.Fail);
+        }
     }
 }


### PR DESCRIPTION
For Maybe to Either conversion:

- Task<Either<TLeft, T>> ToEitherAsync<T, TLeft>(this Maybe<T> maybe, TLeft left)
- Task<Either<TLeft, T>> ToEitherAsync<T, TLeft>(this Task<Maybe<T>> maybeTask, TLeft left)

For Either to Maybe conversion:

- Task<Maybe<TRight>> ToMaybeAsync<TLeft, TRight>(this Either<TLeft, TRight> either)
- Task<Maybe<TRight>> ToMaybeAsync<TLeft, TRight>(this Task<Either<TLeft, TRight>> eitherTask)